### PR TITLE
quick fix to file upload to use given id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,18 @@ require (
 	github.com/appleboy/gofight v2.0.0+incompatible // indirect
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20180617171254-12df4a18567f
 	github.com/buger/jsonparser v0.0.0-20181023193515-52c6e1462ebd // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 // indirect
 	github.com/gin-contrib/static v0.0.0-20180827025113-8cbcdde04781
 	github.com/gin-gonic/gin v1.3.0
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/go-cmp v0.2.0 // indirect
-	github.com/goware/emailx v0.0.0-20171023230436-0bae9679d4e3
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/kr/pty v1.1.3 // indirect
 	github.com/labstack/echo v3.2.1+incompatible // indirect
 	github.com/labstack/gommon v0.2.7 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
@@ -24,7 +24,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mongodb/mongo-go-driver v0.0.18
-	github.com/onsi/gomega v1.4.2 // indirect
 	github.com/sirupsen/logrus v1.1.1
 	github.com/stretchr/testify v1.2.2
 	github.com/tidwall/gjson v1.1.3 // indirect
@@ -35,18 +34,16 @@ require (
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20181030022821-bc7917b19d8f
-	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 // indirect
+	golang.org/x/crypto v0.0.0-20181030022821-bc7917b19d8f // indirect
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20181029174526-d69651ed3497 // indirect
-	golang.org/x/tools v0.0.0-20181121193951-91f80e683c10 // indirect
-	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/appleboy/gofight.v2 v2.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/dgrijalva/jwt-go.v3 v3.2.0 // indirect
-	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/gin-gonic/gin.v1 v1.3.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v8 v8.18.2 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	gopkg.in/yaml.v2 v2.2.1 // indirect
 )

--- a/mongo_connector.go
+++ b/mongo_connector.go
@@ -117,24 +117,24 @@ func GetGridFSBucket(db *mongo.Database, name string, size int32) (*Bucket, erro
 }
 
 // GridFSUploadFile  uploads a file to a Bucket given name of file and the data as a reader object.
-func (b *Bucket) GridFSUploadFile(filename string, file io.Reader) (*objectid.ObjectID, error) {
+func (b *Bucket) GridFSUploadFile(fileID objectid.ObjectID, filename string, file io.Reader) error {
 	uploadStreamOptions := options.GridFSUpload()
 
 	uploadStreamOptions.ChunkSizeBytes = b.ChunkSizeBytes
 
-	fileID, err := b.Bucket.UploadFromStream(filename, file, uploadStreamOptions)
+	err := b.Bucket.UploadFromStreamWithID(fileID, filename, file, uploadStreamOptions)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &fileID, nil
+	return nil
 }
 
 // GridFSDownloadFile given a fileID downloads the file from the bucket.
-func (b *Bucket) GridFSDownloadFile(fileID *objectid.ObjectID) (bytes.Buffer, error) {
+func (b *Bucket) GridFSDownloadFile(fileID objectid.ObjectID) (bytes.Buffer, error) {
 	var fsStream bytes.Buffer
 
-	_, err := b.Bucket.DownloadToStream(*fileID, &fsStream)
+	_, err := b.Bucket.DownloadToStream(fileID, &fsStream)
 	if err != nil {
 		return fsStream, err
 	}
@@ -143,8 +143,8 @@ func (b *Bucket) GridFSDownloadFile(fileID *objectid.ObjectID) (bytes.Buffer, er
 }
 
 // GridFSDeleteFile given a fileID deletes the file from the bucket.
-func (b *Bucket) GridFSDeleteFile(fileID *objectid.ObjectID) error {
-	err := b.Bucket.Delete(*fileID)
+func (b *Bucket) GridFSDeleteFile(fileID objectid.ObjectID) error {
+	err := b.Bucket.Delete(fileID)
 
 	return err
 }


### PR DESCRIPTION
upload now uses given file id instead of generating one so that it is consistent with the submission database